### PR TITLE
updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.gitlab-ci.yml
+.golangci.yml
+.dockerignore
+.gitignore
+charts
+README.md
+renovate.json
+synergy-wholesale-exporter

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,15 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "*"
+      - "main"
     tags:
       - "*"
-    paths-ignore:
-      - ".github/**"
-      - ".gitignore"
-      - LICENSE
-      - README.md
-      - renovate.json
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -81,3 +81,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ env.VERSION }}
+            REVISION=${{ github.sha }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,17 +10,15 @@ on:
     paths-ignore:
       - ".github/**"
       - ".gitignore"
-      - "docker-compose.yaml"
       - LICENSE
       - README.md
       - renovate.json
   pull_request:
     branches:
-      - "master"
+      - "main"
     paths-ignore:
       - ".github/**"
       - ".gitignore"
-      - "docker-compose.yaml"
       - LICENSE
       - README.md
       - renovate.json
@@ -38,7 +36,6 @@ jobs:
           dockerfile: Dockerfile
 
       - name: Determine AppVersion
-        if: github.event_name != 'pull_request'
         id: vars
         run: |
           # Get the short SHA
@@ -80,5 +77,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ env.VERSION }}
+            VERSION=${{ env.VERSION || github.sha }}
             REVISION=${{ github.sha }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: go
 
 on:
   push:
@@ -7,19 +7,30 @@ on:
     paths:
       - go.mod
       - go.sum
-      - "*.go"
+      - "**/*.go"
+      - "synergywholesaleapi/testdata/**"
   pull_request:
     paths:
       - go.mod
       - go.sum
-      - "*.go"
+      - "**/*.go"
+      - "synergywholesaleapi/testdata/**"
 
 permissions:
   contents: read
 
 jobs:
-  golangci:
-    name: lint
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: Test
+        run: go test ./...
+
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+---
+version: "2"
+
+linters:
+  enable:
+    #    - gosec
+    - maintidx
+    - nestif
+    - promlinter
+    - sloglint
+    - unconvert
+    - usestdlibvars
+    - varnamelen
+    - wastedassign
+    - whitespace
+
+formatters:
+  enable:
+    - gofmt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Stage 1: build golang binary
 FROM golang:1.26-alpine as builder
 ARG VERSION="unknown"
+ARG REVISION="unknown"
 WORKDIR /go/src/app
 COPY . .
-RUN CGO_ENABLED=0 go install -ldflags "-extldflags '-static' -X 'main.version=${VERSION}'" -tags timetzdata
+RUN CGO_ENABLED=0 go install -ldflags "-extldflags '-static' -X 'main.version=${VERSION}' -X 'main.revision=${REVISION}'" -tags timetzdata
 
 # Stage 2: setup alpine base for building scratch image
 FROM alpine:3.24.1 as base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
+# syntax=docker/dockerfile:1
+
 # Stage 1: build golang binary
 FROM golang:1.26-alpine as builder
 ARG VERSION="unknown"
 ARG REVISION="unknown"
 WORKDIR /go/src/app
-COPY . .
-RUN CGO_ENABLED=0 go install -ldflags "-extldflags '-static' -X 'main.version=${VERSION}' -X 'main.revision=${REVISION}'" -tags timetzdata
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+COPY *.go ./
+COPY synergywholesaleapi/ ./synergywholesaleapi/
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  CGO_ENABLED=0 go build -ldflags "-extldflags '-static' -X 'main.version=${VERSION}' -X 'main.revision=${REVISION}'" -tags timetzdata -o /go/bin/synergy-wholesale-exporter .
 
 # Stage 2: setup alpine base for building scratch image
 FROM alpine:3.24.1 as base
@@ -14,11 +20,19 @@ RUN adduser -s /bin/true -u 1000 -D -h /app app && \
 
 # Stage 3: create final image from scratch
 FROM scratch
+ARG VERSION="unknown"
+ARG REVISION="unknown"
+LABEL org.opencontainers.image.title="synergy-wholesale-exporter" \
+  org.opencontainers.image.description="Prometheus exporter for Synergy Wholesale domain metrics" \
+  org.opencontainers.image.version="${VERSION}" \
+  org.opencontainers.image.revision="${REVISION}" \
+  org.opencontainers.image.source="https://github.com/yungwood/synergy-wholesale-exporter" \
+  org.opencontainers.image.licenses="MIT"
 WORKDIR /app
-COPY --from=base /etc/passwd /etc/group /etc/shadow /etc/
+COPY --from=base /etc/passwd /etc/group /etc/
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/synergy-wholesale-exporter /usr/bin/synergy-wholesale-exporter
-USER app
+USER 1000:1000
 EXPOSE 8080/tcp
 ENTRYPOINT ["/usr/bin/synergy-wholesale-exporter"]
 CMD []

--- a/README.md
+++ b/README.md
@@ -66,23 +66,18 @@ When prometheus scrapes the `/metrics` endpoint, the cached API response is used
 
 ## Configuration Parameters
 
-- **Command-line Flags**:
-  | Flag | Description | Default |
-  |-----------------------|-------------------------------------------------------|-----------------|
-  | `--reseller-id` | Synergy Wholesale Reseller ID | None (required) |
-  | `--apikey` | Synergy Wholesale API Key | None (required) |
-  | `--address` | Listening port for the metrics endpoint | `:8080` |
-  | `--cache-ttl` | Cache TTL for API responses (in seconds) | `3600` |
-  | `--version` | Print application version and exit |
-  | `--debug` | Enable debug logging | `false` |
-  | `--json` | Output logs in JSON format | `false` |
-  | `--golang-metrics` | Enable default golang metrics collectors | `false` |
+| Flag | Environment Variable | Description | Default | Required |
+|-----------------------|---------------------------------------------|-------------------------------------------------------|-----------------|----------|
+| `--reseller-id` | `SYNERGY_WHOLESALE_RESELLER_ID` | Synergy Wholesale Reseller ID | None | Yes |
+| `--apikey` | `SYNERGY_WHOLESALE_API_KEY` | Synergy Wholesale API Key | None | Yes |
+| `--address` | `SYNERGY_WHOLESALE_EXPORTER_ADDRESS` | Listening address for the metrics endpoint | `:8080` | No |
+| `--cache-ttl` | `SYNERGY_WHOLESALE_EXPORTER_CACHE_TTL` | Cache TTL for API responses (in seconds) | `3600` | No |
+| `--debug` | `SYNERGY_WHOLESALE_EXPORTER_DEBUG` | Enable debug logging (`true` or `false`) | `false` | No |
+| `--json` | `SYNERGY_WHOLESALE_EXPORTER_JSON` | Output logs in JSON format (`true` or `false`) | `false` | No |
+| `--golang-metrics` | `SYNERGY_WHOLESALE_EXPORTER_GOLANG_METRICS` | Enable default golang metrics collectors (`true` or `false`) | `false` | No |
+| `--version` | N/A | Print application version and exit | `false` | No |
 
-- **Environment Variables**:
-  | Variable | Description | Required |
-  |-----------------------------------|-----------------------------------|----------|
-  | `SYNERGY_WHOLESALE_RESELLER_ID` | Synergy Wholesale Reseller ID | if `--reseller-id` is not set |
-  | `SYNERGY_WHOLESALE_API_KEY` | Synergy Wholesale API Key | if `--apikey` is not set |
+Command-line flags take precedence over environment variables.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ docker run -d \
 
 Metrics will be available at `:8080/metrics`.
 
+### Kubernetes
+
+You can deploy Synergy Wholesale Exporter using the provided [helm chart](https://github.com/yungwood/helm-charts/blob/main/charts/synergy-wholesale-exporter).
+
+```bash
+helm repo add yungwood https://yungwood.github.io/helm-charts/
+helm install --name your-release yungwood/synergy-wholesale-exporter
+```
+
 ## Metrics
 
 The exporter exposes the following metrics:
@@ -47,7 +56,7 @@ The exporter exposes the following metrics:
 
 ---
 
-The exporter also includes the default collectors from the [prometheus/client_golang](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus/collectors) library (`go_*` and `process_*` metrics). These can be disabled using the `--no-golang-metrics` flag.
+The exporter can also include the default collectors from the [prometheus/client_golang](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus/collectors) library (`go_*` and `process_*` metrics). These are disabled by default and can be enabled using the `--golang-metrics` flag.
 
 ## Cache Behavior
 
@@ -67,7 +76,7 @@ When prometheus scrapes the `/metrics` endpoint, the cached API response is used
   | `--version` | Print application version and exit |
   | `--debug` | Enable debug logging | `false` |
   | `--json` | Output logs in JSON format | `false` |
-  | `--no-golang-metrics` | Disable default golang metrics collectors | `false` |
+  | `--golang-metrics` | Enable default golang metrics collectors | `false` |
 
 - **Environment Variables**:
   | Variable | Description | Required |

--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ The exporter exposes the following metrics:
 
 | Metric                            | Type  | Description                                                                          | Labels                                                                                                                                                        |
 | --------------------------------- | ----- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `build_info`                      | Gauge | Build information for the application.<br>Gauge always set to `1`.                   | - `version`: Application version<br>- `revision`: Git revision<br>- `goversion`: Go runtime version                                                           |
-| `domain_auto_renew_enable`        | Gauge | Indicates whether auto-renew is enabled for a domain.                                | - `domain`: Domain name                                                                                                                                       |
-| `domain_dnssec_key_info`          | Gauge | Info metric for each DNSSEC key configured for a domain.<br>Gauge always set to `1`. | - `domain`: Domain name<br>- `key_tag`: DNSSEC Key Tag<br>- `algorithm`: DNSSEC Algorithm<br>- `digest_type`: DNSSEC Digest Type<br>- `digest`: DNSSEC Digest |
-| `domain_expiry_timestamp_seconds` | Gauge | UNIX timestamp of the domain expiration.                                             | - `domain`: Domain name<br>- `status`: Domain status (e.g. `ok`)                                                                                              |
-| `domain_name_server_info`         | Gauge | Information about the name servers for a domain.<br>Gauge always set to `1`.         | - `domain`: Domain name<br>- `name_server_info`: Name server (e.g. `ns1.example.com`)                                                                         |
+| `synergy_wholesale_build_info` | Gauge | Build information for the application.<br>Gauge always set to `1`. | - `version`: Application version<br>- `revision`: Git revision<br>- `goversion`: Go runtime version |
+| `synergy_wholesale_domain_auto_renew_enabled` | Gauge | Indicates whether auto-renew is enabled for a domain. | - `domain`: Domain name |
+| `synergy_wholesale_domain_dnssec_key_info` | Gauge | Info metric for each DNSSEC key configured for a domain.<br>Gauge always set to `1`. | - `domain`: Domain name<br>- `key_tag`: DNSSEC Key Tag<br>- `algorithm`: DNSSEC Algorithm<br>- `digest_type`: DNSSEC Digest Type<br>- `digest`: DNSSEC Digest |
+| `synergy_wholesale_domain_expiry_timestamp_seconds` | Gauge | UNIX timestamp of the domain expiration. | - `domain`: Domain name<br>- `status`: Domain status (e.g. `ok`) |
+| `synergy_wholesale_domain_name_server_info` | Gauge | Information about the name servers for a domain.<br>Gauge always set to `1`. | - `domain`: Domain name<br>- `name_server`: Name server (e.g. `ns1.example.com`) |
+| `synergy_wholesale_http_requests_total` | Counter | Total number of HTTP requests handled by the exporter. | - `code`: HTTP status code<br>- `method`: HTTP method<br>- `handler`: Handler name (`metrics`, `liveness`, `readiness`) |
+| `synergy_wholesale_api_requests_total` | Counter | Total number of HTTP requests sent to the Synergy Wholesale API. | - `code`: HTTP status code (`0` for transport errors)<br>- `result`: Request result (`success` or `error`) |
 
 ---
 
@@ -86,24 +88,32 @@ For more details on the Synergy Wholesale API, visit the [Synergy Wholesale API 
 ## Example Metrics Output
 
 ```text
-# HELP build_info Application build information
-# TYPE build_info gauge
-build_info{version="0.0.1", revision="abc1234", goversion="go1.20.5"} 1
+# HELP synergy_wholesale_build_info Application build information
+# TYPE synergy_wholesale_build_info gauge
+synergy_wholesale_build_info{version="0.0.1", revision="abc1234", goversion="go1.20.5"} 1
 
-# HELP domain_auto_renew_enable Domain auto-renewal status
-# TYPE domain_auto_renew_enable gauge
-domain_auto_renew_enable{domain="example.com"} 1
+# HELP synergy_wholesale_domain_auto_renew_enabled Domain auto-renewal status
+# TYPE synergy_wholesale_domain_auto_renew_enabled gauge
+synergy_wholesale_domain_auto_renew_enabled{domain="example.com"} 1
 
-# HELP domain_dnssec_key_info Domain DNSSEC key info
-# TYPE domain_dnssec_key_info gauge
-domain_dnssec_key_count{algorithm="13",digest="6BDEC6...",digest_type="2",domain="example.com",key_tag="1234"} 1
+# HELP synergy_wholesale_domain_dnssec_key_info Domain DNSSEC key info
+# TYPE synergy_wholesale_domain_dnssec_key_info gauge
+synergy_wholesale_domain_dnssec_key_info{algorithm="13",digest="6BDEC6...",digest_type="2",domain="example.com",key_tag="1234"} 1
 
-# HELP domain_expiry_timestamp_seconds Domain expiry timestamp in seconds
-# TYPE domain_expiry_timestamp_seconds gauge
-domain_expiry_timestamp_seconds{domain="example.com", status="ok"} 1735689600
+# HELP synergy_wholesale_domain_expiry_timestamp_seconds Domain expiry timestamp in seconds
+# TYPE synergy_wholesale_domain_expiry_timestamp_seconds gauge
+synergy_wholesale_domain_expiry_timestamp_seconds{domain="example.com", status="ok"} 1735689600
 
-# HELP domain_name_server_info Domain name server info
-# TYPE domain_name_server_info gauge
-domain_name_server_info{domain="example.com", name_server_info="ns1.example.com"} 1
-domain_name_server_info{domain="example.com", name_server_info="ns2.example.com"} 1
+# HELP synergy_wholesale_domain_name_server_info Domain name server info
+# TYPE synergy_wholesale_domain_name_server_info gauge
+synergy_wholesale_domain_name_server_info{domain="example.com", name_server="ns1.example.com"} 1
+synergy_wholesale_domain_name_server_info{domain="example.com", name_server="ns2.example.com"} 1
+
+# HELP synergy_wholesale_http_requests_total Total number of HTTP requests handled by the exporter.
+# TYPE synergy_wholesale_http_requests_total counter
+synergy_wholesale_http_requests_total{code="200",handler="metrics",method="GET"} 1
+
+# HELP synergy_wholesale_api_requests_total Total number of HTTP requests sent to the Synergy Wholesale API.
+# TYPE synergy_wholesale_api_requests_total counter
+synergy_wholesale_api_requests_total{code="200",result="success"} 1
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The exporter exposes the following metrics:
 
 | Metric                            | Type  | Description                                                                          | Labels                                                                                                                                                        |
 | --------------------------------- | ----- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `build_info`                      | Gauge | Build information for the application.<br>Gauge always set to `1`.                   | - `version`: Application version<br>- `goversion`: Go runtime version                                                                                         |
+| `build_info`                      | Gauge | Build information for the application.<br>Gauge always set to `1`.                   | - `version`: Application version<br>- `revision`: Git revision<br>- `goversion`: Go runtime version                                                           |
 | `domain_auto_renew_enable`        | Gauge | Indicates whether auto-renew is enabled for a domain.                                | - `domain`: Domain name                                                                                                                                       |
 | `domain_dnssec_key_info`          | Gauge | Info metric for each DNSSEC key configured for a domain.<br>Gauge always set to `1`. | - `domain`: Domain name<br>- `key_tag`: DNSSEC Key Tag<br>- `algorithm`: DNSSEC Algorithm<br>- `digest_type`: DNSSEC Digest Type<br>- `digest`: DNSSEC Digest |
 | `domain_expiry_timestamp_seconds` | Gauge | UNIX timestamp of the domain expiration.                                             | - `domain`: Domain name<br>- `status`: Domain status (e.g. `ok`)                                                                                              |
@@ -88,7 +88,7 @@ For more details on the Synergy Wholesale API, visit the [Synergy Wholesale API 
 ```text
 # HELP build_info Application build information
 # TYPE build_info gauge
-build_info{version="0.0.1", goversion="go1.20.5"} 1
+build_info{version="0.0.1", revision="abc1234", goversion="go1.20.5"} 1
 
 # HELP domain_auto_renew_enable Domain auto-renewal status
 # TYPE domain_auto_renew_enable gauge

--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ The exporter exposes the following metrics:
 | --------------------------------- | ----- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `synergy_wholesale_build_info` | Gauge | Build information for the application.<br>Gauge always set to `1`. | - `version`: Application version<br>- `revision`: Git revision<br>- `goversion`: Go runtime version |
 | `synergy_wholesale_domain_auto_renew_enabled` | Gauge | Indicates whether auto-renew is enabled for a domain. | - `domain`: Domain name |
-| `synergy_wholesale_domain_dnssec_key_info` | Gauge | Info metric for each DNSSEC key configured for a domain.<br>Gauge always set to `1`. | - `domain`: Domain name<br>- `key_tag`: DNSSEC Key Tag<br>- `algorithm`: DNSSEC Algorithm<br>- `digest_type`: DNSSEC Digest Type<br>- `digest`: DNSSEC Digest |
+| `synergy_wholesale_domain_dnssec_key_info` | Gauge | Info metric for each DNSSEC key configured for a domain. Disabled by default.<br>Gauge always set to `1`. | - `domain`: Domain name<br>- `key_tag`: DNSSEC Key Tag<br>- `algorithm`: DNSSEC Algorithm<br>- `digest_type`: DNSSEC Digest Type<br>- `digest`: DNSSEC Digest |
 | `synergy_wholesale_domain_expiry_timestamp_seconds` | Gauge | UNIX timestamp of the domain expiration. | - `domain`: Domain name<br>- `status`: Domain status (e.g. `ok`) |
 | `synergy_wholesale_domain_name_server_info` | Gauge | Information about the name servers for a domain.<br>Gauge always set to `1`. | - `domain`: Domain name<br>- `name_server`: Name server (e.g. `ns1.example.com`) |
 | `synergy_wholesale_http_requests_total` | Counter | Total number of HTTP requests handled by the exporter. | - `code`: HTTP status code<br>- `method`: HTTP method<br>- `handler`: Handler name (`metrics`, `liveness`, `readiness`) |
 | `synergy_wholesale_api_requests_total` | Counter | Total number of HTTP requests sent to the Synergy Wholesale API. | - `code`: HTTP status code (`0` for transport errors)<br>- `result`: Request result (`success` or `error`) |
 
 ---
+
+DNSSEC key info metrics are disabled by default and can be enabled using the `--dnssec-metrics` flag.
 
 The exporter can also include the default collectors from the [prometheus/client_golang](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus/collectors) library (`go_*` and `process_*` metrics). These are disabled by default and can be enabled using the `--golang-metrics` flag.
 
@@ -77,6 +79,7 @@ When prometheus scrapes the `/metrics` endpoint, the cached API response is used
 | `--debug` | `SYNERGY_WHOLESALE_EXPORTER_DEBUG` | Enable debug logging (`true` or `false`) | `false` | No |
 | `--json` | `SYNERGY_WHOLESALE_EXPORTER_JSON` | Output logs in JSON format (`true` or `false`) | `false` | No |
 | `--golang-metrics` | `SYNERGY_WHOLESALE_EXPORTER_GOLANG_METRICS` | Enable default golang metrics collectors (`true` or `false`) | `false` | No |
+| `--dnssec-metrics` | `SYNERGY_WHOLESALE_EXPORTER_DNSSEC_METRICS` | Enable DNSSEC key info metrics (`true` or `false`) | `false` | No |
 | `--version` | N/A | Print application version and exit | `false` | No |
 
 Command-line flags take precedence over environment variables.

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	api "github.com/yungwood/synergy-wholesale-exporter/synergywholesaleapi"
+)
+
+var (
+	listDomainsResponse api.ListDomainsResponse
+	cacheExpires        int64
+	cacheMu             sync.Mutex
+)
+
+func getDomains() api.ListDomainsResponse {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
+	if cacheExpires > time.Now().Unix() {
+		slog.Debug("Using cached Synergy Wholesale domain response", "cache_expires", cacheExpires)
+		return listDomainsResponse
+	}
+
+	slog.Info("Sending listDomains request to Synergy Wholesale API", "reseller_id", *resellerID)
+
+	request := api.ListDomainsRequest{
+		APIKey:     *apiKey,
+		ResellerID: *resellerID,
+	}
+
+	response, err := api.Send(request)
+	if err != nil {
+		slog.Error("Error sending SOAP request", "error", err)
+		return api.ListDomainsResponse{}
+	}
+
+	listDomainsResponse = response
+	cacheExpires = time.Now().Unix() + *cacheTTLSeconds
+	slog.Info(
+		"Updated Synergy Wholesale domain cache",
+		"domain_count", len(response.Return.DomainList),
+		"cache_expires", cacheExpires,
+	)
+
+	return response
+}

--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var BuildInfo = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "build_info",
+		Help: "Application build information",
+	},
+	[]string{"version", "goversion"},
+)
+
+type Collector struct {
+	domainAutoRenew     *prometheus.Desc
+	domainExpiry        *prometheus.Desc
+	domainNameServer    *prometheus.Desc
+	domainDNSSECKeyInfo *prometheus.Desc
+}
+
+func newCollector() *Collector {
+	return &Collector{
+		domainAutoRenew: prometheus.NewDesc("domain_auto_renew_enable",
+			"Domain auto-renewal status",
+			[]string{"domain"},
+			nil,
+		),
+		domainDNSSECKeyInfo: prometheus.NewDesc("domain_dnssec_key_info",
+			"Domain DNSSEC key info",
+			[]string{"domain", "key_tag", "algorithm", "digest_type", "digest"},
+			nil,
+		),
+		domainExpiry: prometheus.NewDesc("domain_expiry_timestamp_seconds",
+			"Domain expiry timestamp in seconds",
+			[]string{"domain", "status"},
+			nil,
+		),
+		domainNameServer: prometheus.NewDesc("domain_name_server_info",
+			"Domain name server info",
+			[]string{"domain", "name_server"},
+			nil,
+		),
+	}
+}
+
+func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- collector.domainAutoRenew
+	ch <- collector.domainDNSSECKeyInfo
+	ch <- collector.domainExpiry
+	ch <- collector.domainNameServer
+}
+
+func (collector *Collector) Collect(channel chan<- prometheus.Metric) {
+	listDomainsResp := getDomains()
+	for _, domain := range listDomainsResp.Return.DomainList {
+		// skip domains where api status != OK they are usually old/deleted
+		if domain.Status != "OK" {
+			slog.Debug(
+				"Skipping domain with non-OK API status",
+				"domain", domain.DomainName,
+				"status", domain.Status,
+				"error_message", domain.ErrorMessage,
+			)
+			continue
+		}
+
+		channel <- prometheus.MustNewConstMetric(
+			collector.domainAutoRenew,
+			prometheus.GaugeValue,
+			float64(domain.AutoRenew),
+			domain.DomainName,
+		)
+		for _, dnsSECKey := range domain.DNSSECKeys {
+			channel <- prometheus.MustNewConstMetric(
+				collector.domainDNSSECKeyInfo,
+				prometheus.GaugeValue,
+				float64(1),
+				domain.DomainName, dnsSECKey.KeyTag, dnsSECKey.Algorithm, dnsSECKey.DigestType, dnsSECKey.Digest,
+			)
+		}
+		channel <- prometheus.MustNewConstMetric(
+			collector.domainExpiry,
+			prometheus.GaugeValue,
+			float64(domain.GetDomainExpiryTimestamp()),
+			domain.DomainName, domain.DomainStatus,
+		)
+
+		for _, server := range domain.NameServers {
+			channel <- prometheus.MustNewConstMetric(
+				collector.domainNameServer,
+				prometheus.GaugeValue,
+				float64(1),
+				domain.DomainName, server,
+			)
+		}
+	}
+}

--- a/collector.go
+++ b/collector.go
@@ -11,7 +11,7 @@ var BuildInfo = prometheus.NewGaugeVec(
 		Name: "build_info",
 		Help: "Application build information",
 	},
-	[]string{"version", "goversion"},
+	[]string{"version", "revision", "goversion"},
 )
 
 type Collector struct {

--- a/collector.go
+++ b/collector.go
@@ -6,18 +6,22 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const metricNamespace = "synergy_wholesale"
+
 var BuildInfo = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Name: "build_info",
-		Help: "Application build information",
+		Namespace: metricNamespace,
+		Name:      "build_info",
+		Help:      "Application build information",
 	},
 	[]string{"version", "revision", "goversion"},
 )
 
 var HTTPRequestsTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "http_requests_total",
-		Help: "Total number of HTTP requests handled by the exporter.",
+		Namespace: metricNamespace,
+		Name:      "http_requests_total",
+		Help:      "Total number of HTTP requests handled by the exporter.",
 	},
 	[]string{"code", "method", "handler"},
 )
@@ -31,27 +35,31 @@ type Collector struct {
 
 func newCollector() *Collector {
 	return &Collector{
-		domainAutoRenew: prometheus.NewDesc("domain_auto_renew_enable",
+		domainAutoRenew: prometheus.NewDesc(metricName("domain_auto_renew_enabled"),
 			"Domain auto-renewal status",
 			[]string{"domain"},
 			nil,
 		),
-		domainDNSSECKeyInfo: prometheus.NewDesc("domain_dnssec_key_info",
+		domainDNSSECKeyInfo: prometheus.NewDesc(metricName("domain_dnssec_key_info"),
 			"Domain DNSSEC key info",
 			[]string{"domain", "key_tag", "algorithm", "digest_type", "digest"},
 			nil,
 		),
-		domainExpiry: prometheus.NewDesc("domain_expiry_timestamp_seconds",
+		domainExpiry: prometheus.NewDesc(metricName("domain_expiry_timestamp_seconds"),
 			"Domain expiry timestamp in seconds",
 			[]string{"domain", "status"},
 			nil,
 		),
-		domainNameServer: prometheus.NewDesc("domain_name_server_info",
+		domainNameServer: prometheus.NewDesc(metricName("domain_name_server_info"),
 			"Domain name server info",
 			[]string{"domain", "name_server"},
 			nil,
 		),
 	}
+}
+
+func metricName(name string) string {
+	return prometheus.BuildFQName(metricNamespace, "", name)
 }
 
 func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {

--- a/collector.go
+++ b/collector.go
@@ -64,7 +64,9 @@ func metricName(name string) string {
 
 func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.domainAutoRenew
-	ch <- collector.domainDNSSECKeyInfo
+	if *enableDNSSECMetrics {
+		ch <- collector.domainDNSSECKeyInfo
+	}
 	ch <- collector.domainExpiry
 	ch <- collector.domainNameServer
 }
@@ -89,13 +91,15 @@ func (collector *Collector) Collect(channel chan<- prometheus.Metric) {
 			float64(domain.AutoRenew),
 			domain.DomainName,
 		)
-		for _, dnsSECKey := range domain.DNSSECKeys {
-			channel <- prometheus.MustNewConstMetric(
-				collector.domainDNSSECKeyInfo,
-				prometheus.GaugeValue,
-				float64(1),
-				domain.DomainName, dnsSECKey.KeyTag, dnsSECKey.Algorithm, dnsSECKey.DigestType, dnsSECKey.Digest,
-			)
+		if *enableDNSSECMetrics {
+			for _, dnsSECKey := range domain.DNSSECKeys {
+				channel <- prometheus.MustNewConstMetric(
+					collector.domainDNSSECKeyInfo,
+					prometheus.GaugeValue,
+					float64(1),
+					domain.DomainName, dnsSECKey.KeyTag, dnsSECKey.Algorithm, dnsSECKey.DigestType, dnsSECKey.Digest,
+				)
+			}
 		}
 		channel <- prometheus.MustNewConstMetric(
 			collector.domainExpiry,

--- a/collector.go
+++ b/collector.go
@@ -62,13 +62,13 @@ func metricName(name string) string {
 	return prometheus.BuildFQName(metricNamespace, "", name)
 }
 
-func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- collector.domainAutoRenew
+func (collector *Collector) Describe(channel chan<- *prometheus.Desc) {
+	channel <- collector.domainAutoRenew
 	if *enableDNSSECMetrics {
-		ch <- collector.domainDNSSECKeyInfo
+		channel <- collector.domainDNSSECKeyInfo
 	}
-	ch <- collector.domainExpiry
-	ch <- collector.domainNameServer
+	channel <- collector.domainExpiry
+	channel <- collector.domainNameServer
 }
 
 func (collector *Collector) Collect(channel chan<- prometheus.Metric) {

--- a/collector.go
+++ b/collector.go
@@ -14,6 +14,14 @@ var BuildInfo = prometheus.NewGaugeVec(
 	[]string{"version", "revision", "goversion"},
 )
 
+var HTTPRequestsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Total number of HTTP requests handled by the exporter.",
+	},
+	[]string{"code", "method", "handler"},
+)
+
 type Collector struct {
 	domainAutoRenew     *prometheus.Desc
 	domainExpiry        *prometheus.Desc

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ const (
 	envDebug         = "SYNERGY_WHOLESALE_EXPORTER_DEBUG"
 	envJSON          = "SYNERGY_WHOLESALE_EXPORTER_JSON"
 	envGolangMetrics = "SYNERGY_WHOLESALE_EXPORTER_GOLANG_METRICS"
+	envDNSSECMetrics = "SYNERGY_WHOLESALE_EXPORTER_DNSSEC_METRICS"
 )
 
 func applyEnvConfig() error {
@@ -26,6 +27,7 @@ func applyEnvConfig() error {
 		debugLogging:        debugLogging,
 		jsonLogging:         jsonLogging,
 		enableGolangMetrics: enableGolangMetrics,
+		enableDNSSECMetrics: enableDNSSECMetrics,
 	})
 }
 
@@ -37,6 +39,7 @@ type envConfig struct {
 	debugLogging        *bool
 	jsonLogging         *bool
 	enableGolangMetrics *bool
+	enableDNSSECMetrics *bool
 }
 
 func applyEnvConfigFromFlagSet(flags *flag.FlagSet, config envConfig) error {
@@ -54,6 +57,9 @@ func applyEnvConfigFromFlagSet(flags *flag.FlagSet, config envConfig) error {
 		return err
 	}
 	if err := setBoolFromEnv(flags, "golang-metrics", config.enableGolangMetrics, envGolangMetrics); err != nil {
+		return err
+	}
+	if err := setBoolFromEnv(flags, "dnssec-metrics", config.enableDNSSECMetrics, envDNSSECMetrics); err != nil {
 		return err
 	}
 

--- a/config.go
+++ b/config.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+const (
+	envResellerID    = "SYNERGY_WHOLESALE_RESELLER_ID"
+	envAPIKey        = "SYNERGY_WHOLESALE_API_KEY"
+	envAddress       = "SYNERGY_WHOLESALE_EXPORTER_ADDRESS"
+	envCacheTTL      = "SYNERGY_WHOLESALE_EXPORTER_CACHE_TTL"
+	envDebug         = "SYNERGY_WHOLESALE_EXPORTER_DEBUG"
+	envJSON          = "SYNERGY_WHOLESALE_EXPORTER_JSON"
+	envGolangMetrics = "SYNERGY_WHOLESALE_EXPORTER_GOLANG_METRICS"
+)
+
+func applyEnvConfig() error {
+	setStringFromEnv("reseller-id", resellerID, envResellerID)
+	setStringFromEnv("apikey", apiKey, envAPIKey)
+	setStringFromEnv("address", listenAddress, envAddress)
+
+	if err := setInt64FromEnv("cache-ttl", cacheTTLSeconds, envCacheTTL); err != nil {
+		return err
+	}
+	if err := setBoolFromEnv("debug", debugLogging, envDebug); err != nil {
+		return err
+	}
+	if err := setBoolFromEnv("json", jsonLogging, envJSON); err != nil {
+		return err
+	}
+	if err := setBoolFromEnv("golang-metrics", enableGolangMetrics, envGolangMetrics); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setStringFromEnv(flagName string, target *string, envName string) {
+	if wasFlagSet(flagName) {
+		return
+	}
+	if value := os.Getenv(envName); value != "" {
+		*target = value
+	}
+}
+
+func setInt64FromEnv(flagName string, target *int64, envName string) error {
+	if wasFlagSet(flagName) {
+		return nil
+	}
+	value := os.Getenv(envName)
+	if value == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid %s value %q: %w", envName, value, err)
+	}
+	*target = parsed
+	return nil
+}
+
+func setBoolFromEnv(flagName string, target *bool, envName string) error {
+	if wasFlagSet(flagName) {
+		return nil
+	}
+	value := os.Getenv(envName)
+	if value == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return fmt.Errorf("invalid %s value %q: %w", envName, value, err)
+	}
+	*target = parsed
+	return nil
+}
+
+func wasFlagSet(name string) bool {
+	wasSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			wasSet = true
+		}
+	})
+	return wasSet
+}

--- a/config.go
+++ b/config.go
@@ -18,28 +18,50 @@ const (
 )
 
 func applyEnvConfig() error {
-	setStringFromEnv("reseller-id", resellerID, envResellerID)
-	setStringFromEnv("apikey", apiKey, envAPIKey)
-	setStringFromEnv("address", listenAddress, envAddress)
+	return applyEnvConfigFromFlagSet(flag.CommandLine, envConfig{
+		resellerID:          resellerID,
+		apiKey:              apiKey,
+		listenAddress:       listenAddress,
+		cacheTTLSeconds:     cacheTTLSeconds,
+		debugLogging:        debugLogging,
+		jsonLogging:         jsonLogging,
+		enableGolangMetrics: enableGolangMetrics,
+	})
+}
 
-	if err := setInt64FromEnv("cache-ttl", cacheTTLSeconds, envCacheTTL); err != nil {
+type envConfig struct {
+	resellerID          *string
+	apiKey              *string
+	listenAddress       *string
+	cacheTTLSeconds     *int64
+	debugLogging        *bool
+	jsonLogging         *bool
+	enableGolangMetrics *bool
+}
+
+func applyEnvConfigFromFlagSet(flags *flag.FlagSet, config envConfig) error {
+	setStringFromEnv(flags, "reseller-id", config.resellerID, envResellerID)
+	setStringFromEnv(flags, "apikey", config.apiKey, envAPIKey)
+	setStringFromEnv(flags, "address", config.listenAddress, envAddress)
+
+	if err := setInt64FromEnv(flags, "cache-ttl", config.cacheTTLSeconds, envCacheTTL); err != nil {
 		return err
 	}
-	if err := setBoolFromEnv("debug", debugLogging, envDebug); err != nil {
+	if err := setBoolFromEnv(flags, "debug", config.debugLogging, envDebug); err != nil {
 		return err
 	}
-	if err := setBoolFromEnv("json", jsonLogging, envJSON); err != nil {
+	if err := setBoolFromEnv(flags, "json", config.jsonLogging, envJSON); err != nil {
 		return err
 	}
-	if err := setBoolFromEnv("golang-metrics", enableGolangMetrics, envGolangMetrics); err != nil {
+	if err := setBoolFromEnv(flags, "golang-metrics", config.enableGolangMetrics, envGolangMetrics); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func setStringFromEnv(flagName string, target *string, envName string) {
-	if wasFlagSet(flagName) {
+func setStringFromEnv(flags *flag.FlagSet, flagName string, target *string, envName string) {
+	if wasFlagSet(flags, flagName) {
 		return
 	}
 	if value := os.Getenv(envName); value != "" {
@@ -47,8 +69,8 @@ func setStringFromEnv(flagName string, target *string, envName string) {
 	}
 }
 
-func setInt64FromEnv(flagName string, target *int64, envName string) error {
-	if wasFlagSet(flagName) {
+func setInt64FromEnv(flags *flag.FlagSet, flagName string, target *int64, envName string) error {
+	if wasFlagSet(flags, flagName) {
 		return nil
 	}
 	value := os.Getenv(envName)
@@ -63,8 +85,8 @@ func setInt64FromEnv(flagName string, target *int64, envName string) error {
 	return nil
 }
 
-func setBoolFromEnv(flagName string, target *bool, envName string) error {
-	if wasFlagSet(flagName) {
+func setBoolFromEnv(flags *flag.FlagSet, flagName string, target *bool, envName string) error {
+	if wasFlagSet(flags, flagName) {
 		return nil
 	}
 	value := os.Getenv(envName)
@@ -79,9 +101,9 @@ func setBoolFromEnv(flagName string, target *bool, envName string) error {
 	return nil
 }
 
-func wasFlagSet(name string) bool {
+func wasFlagSet(flags *flag.FlagSet, name string) bool {
 	wasSet := false
-	flag.Visit(func(f *flag.Flag) {
+	flags.Visit(func(f *flag.Flag) {
 		if f.Name == name {
 			wasSet = true
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestApplyEnvConfigFromFlagSetUsesEnvironmentForUnsetFlags(t *testing.T) {
+	flags, config := newTestEnvConfig()
+	t.Setenv(envResellerID, "env-reseller")
+	t.Setenv(envAPIKey, "env-api-key")
+	t.Setenv(envAddress, ":9090")
+	t.Setenv(envCacheTTL, "120")
+	t.Setenv(envDebug, "true")
+	t.Setenv(envJSON, "true")
+	t.Setenv(envGolangMetrics, "true")
+
+	if err := applyEnvConfigFromFlagSet(flags, config); err != nil {
+		t.Fatalf("apply env config: %v", err)
+	}
+
+	if *config.resellerID != "env-reseller" {
+		t.Errorf("reseller ID = %q, want env-reseller", *config.resellerID)
+	}
+	if *config.apiKey != "env-api-key" {
+		t.Errorf("API key = %q, want env-api-key", *config.apiKey)
+	}
+	if *config.listenAddress != ":9090" {
+		t.Errorf("listen address = %q, want :9090", *config.listenAddress)
+	}
+	if *config.cacheTTLSeconds != 120 {
+		t.Errorf("cache TTL = %d, want 120", *config.cacheTTLSeconds)
+	}
+	if !*config.debugLogging {
+		t.Error("debug logging = false, want true")
+	}
+	if !*config.jsonLogging {
+		t.Error("JSON logging = false, want true")
+	}
+	if !*config.enableGolangMetrics {
+		t.Error("golang metrics = false, want true")
+	}
+}
+
+func TestApplyEnvConfigFromFlagSetKeepsExplicitFlags(t *testing.T) {
+	flags, config := newTestEnvConfig()
+	t.Setenv(envResellerID, "env-reseller")
+	t.Setenv(envAPIKey, "env-api-key")
+	t.Setenv(envAddress, ":9090")
+	t.Setenv(envCacheTTL, "120")
+	t.Setenv(envDebug, "true")
+	t.Setenv(envJSON, "true")
+	t.Setenv(envGolangMetrics, "true")
+
+	mustSetFlag(t, flags, "reseller-id", "flag-reseller")
+	mustSetFlag(t, flags, "apikey", "flag-api-key")
+	mustSetFlag(t, flags, "address", ":8081")
+	mustSetFlag(t, flags, "cache-ttl", "300")
+	mustSetFlag(t, flags, "debug", "false")
+	mustSetFlag(t, flags, "json", "false")
+	mustSetFlag(t, flags, "golang-metrics", "false")
+
+	if err := applyEnvConfigFromFlagSet(flags, config); err != nil {
+		t.Fatalf("apply env config: %v", err)
+	}
+
+	if *config.resellerID != "flag-reseller" {
+		t.Errorf("reseller ID = %q, want flag-reseller", *config.resellerID)
+	}
+	if *config.apiKey != "flag-api-key" {
+		t.Errorf("API key = %q, want flag-api-key", *config.apiKey)
+	}
+	if *config.listenAddress != ":8081" {
+		t.Errorf("listen address = %q, want :8081", *config.listenAddress)
+	}
+	if *config.cacheTTLSeconds != 300 {
+		t.Errorf("cache TTL = %d, want 300", *config.cacheTTLSeconds)
+	}
+	if *config.debugLogging {
+		t.Error("debug logging = true, want false")
+	}
+	if *config.jsonLogging {
+		t.Error("JSON logging = true, want false")
+	}
+	if *config.enableGolangMetrics {
+		t.Error("golang metrics = true, want false")
+	}
+}
+
+func TestApplyEnvConfigFromFlagSetRejectsInvalidValues(t *testing.T) {
+	t.Run("cache TTL", func(t *testing.T) {
+		flags, config := newTestEnvConfig()
+		t.Setenv(envCacheTTL, "invalid")
+
+		err := applyEnvConfigFromFlagSet(flags, config)
+		if err == nil {
+			t.Fatal("apply env config error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), envCacheTTL) {
+			t.Errorf("error = %q, want %s", err.Error(), envCacheTTL)
+		}
+	})
+
+	t.Run("debug", func(t *testing.T) {
+		flags, config := newTestEnvConfig()
+		t.Setenv(envDebug, "invalid")
+
+		err := applyEnvConfigFromFlagSet(flags, config)
+		if err == nil {
+			t.Fatal("apply env config error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), envDebug) {
+			t.Errorf("error = %q, want %s", err.Error(), envDebug)
+		}
+	})
+}
+
+func newTestEnvConfig() (*flag.FlagSet, envConfig) {
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	var resellerID string
+	var apiKey string
+	var listenAddress = ":8080"
+	var cacheTTLSeconds int64 = 3600
+	var debugLogging bool
+	var jsonLogging bool
+	var enableGolangMetrics bool
+
+	flags.StringVar(&resellerID, "reseller-id", resellerID, "")
+	flags.StringVar(&apiKey, "apikey", apiKey, "")
+	flags.StringVar(&listenAddress, "address", listenAddress, "")
+	flags.Int64Var(&cacheTTLSeconds, "cache-ttl", cacheTTLSeconds, "")
+	flags.BoolVar(&debugLogging, "debug", debugLogging, "")
+	flags.BoolVar(&jsonLogging, "json", jsonLogging, "")
+	flags.BoolVar(&enableGolangMetrics, "golang-metrics", enableGolangMetrics, "")
+
+	return flags, envConfig{
+		resellerID:          &resellerID,
+		apiKey:              &apiKey,
+		listenAddress:       &listenAddress,
+		cacheTTLSeconds:     &cacheTTLSeconds,
+		debugLogging:        &debugLogging,
+		jsonLogging:         &jsonLogging,
+		enableGolangMetrics: &enableGolangMetrics,
+	}
+}
+
+func mustSetFlag(t *testing.T, flags *flag.FlagSet, name string, value string) {
+	t.Helper()
+	if err := flags.Set(name, value); err != nil {
+		t.Fatalf("set flag %s: %v", name, err)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -15,6 +15,7 @@ func TestApplyEnvConfigFromFlagSetUsesEnvironmentForUnsetFlags(t *testing.T) {
 	t.Setenv(envDebug, "true")
 	t.Setenv(envJSON, "true")
 	t.Setenv(envGolangMetrics, "true")
+	t.Setenv(envDNSSECMetrics, "true")
 
 	if err := applyEnvConfigFromFlagSet(flags, config); err != nil {
 		t.Fatalf("apply env config: %v", err)
@@ -41,6 +42,9 @@ func TestApplyEnvConfigFromFlagSetUsesEnvironmentForUnsetFlags(t *testing.T) {
 	if !*config.enableGolangMetrics {
 		t.Error("golang metrics = false, want true")
 	}
+	if !*config.enableDNSSECMetrics {
+		t.Error("DNSSEC metrics = false, want true")
+	}
 }
 
 func TestApplyEnvConfigFromFlagSetKeepsExplicitFlags(t *testing.T) {
@@ -52,6 +56,7 @@ func TestApplyEnvConfigFromFlagSetKeepsExplicitFlags(t *testing.T) {
 	t.Setenv(envDebug, "true")
 	t.Setenv(envJSON, "true")
 	t.Setenv(envGolangMetrics, "true")
+	t.Setenv(envDNSSECMetrics, "true")
 
 	mustSetFlag(t, flags, "reseller-id", "flag-reseller")
 	mustSetFlag(t, flags, "apikey", "flag-api-key")
@@ -60,6 +65,7 @@ func TestApplyEnvConfigFromFlagSetKeepsExplicitFlags(t *testing.T) {
 	mustSetFlag(t, flags, "debug", "false")
 	mustSetFlag(t, flags, "json", "false")
 	mustSetFlag(t, flags, "golang-metrics", "false")
+	mustSetFlag(t, flags, "dnssec-metrics", "false")
 
 	if err := applyEnvConfigFromFlagSet(flags, config); err != nil {
 		t.Fatalf("apply env config: %v", err)
@@ -85,6 +91,9 @@ func TestApplyEnvConfigFromFlagSetKeepsExplicitFlags(t *testing.T) {
 	}
 	if *config.enableGolangMetrics {
 		t.Error("golang metrics = true, want false")
+	}
+	if *config.enableDNSSECMetrics {
+		t.Error("DNSSEC metrics = true, want false")
 	}
 }
 
@@ -126,6 +135,7 @@ func newTestEnvConfig() (*flag.FlagSet, envConfig) {
 	var debugLogging bool
 	var jsonLogging bool
 	var enableGolangMetrics bool
+	var enableDNSSECMetrics bool
 
 	flags.StringVar(&resellerID, "reseller-id", resellerID, "")
 	flags.StringVar(&apiKey, "apikey", apiKey, "")
@@ -134,6 +144,7 @@ func newTestEnvConfig() (*flag.FlagSet, envConfig) {
 	flags.BoolVar(&debugLogging, "debug", debugLogging, "")
 	flags.BoolVar(&jsonLogging, "json", jsonLogging, "")
 	flags.BoolVar(&enableGolangMetrics, "golang-metrics", enableGolangMetrics, "")
+	flags.BoolVar(&enableDNSSECMetrics, "dnssec-metrics", enableDNSSECMetrics, "")
 
 	return flags, envConfig{
 		resellerID:          &resellerID,
@@ -143,6 +154,7 @@ func newTestEnvConfig() (*flag.FlagSet, envConfig) {
 		debugLogging:        &debugLogging,
 		jsonLogging:         &jsonLogging,
 		enableGolangMetrics: &enableGolangMetrics,
+		enableDNSSECMetrics: &enableDNSSECMetrics,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,6 +21,7 @@ var version = "development"
 var (
 	listDomainsResponse api.ListDomainsResponse
 	cacheExpires        int64
+	cacheMu             sync.Mutex
 )
 
 var (
@@ -122,6 +124,9 @@ func (collector *Collector) Collect(channel chan<- prometheus.Metric) {
 }
 
 func getDomains() api.ListDomainsResponse {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
 	if cacheExpires > time.Now().Unix() {
 		return listDomainsResponse
 	}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,10 @@ func main() {
 		fmt.Println("version:", version)
 		os.Exit(0)
 	}
+	if err := applyEnvConfig(); err != nil {
+		fmt.Fprintf(os.Stderr, "configuration error: %v\n", err)
+		os.Exit(1)
+	}
 
 	// setup logging options
 	loggingLevel := slog.LevelInfo // default loglevel
@@ -53,17 +57,11 @@ func main() {
 		logger = slog.New(slog.NewTextHandler(os.Stdout, opts))
 	}
 	slog.SetDefault(logger)
-	if *resellerID == "" {
-		*resellerID = os.Getenv("SYNERGY_WHOLESALE_RESELLER_ID")
-	}
 
 	// check for required parameters
 	if *resellerID == "" {
 		slog.Error("Reseller ID not set!")
 		os.Exit(1)
-	}
-	if *apiKey == "" {
-		*apiKey = os.Getenv("SYNERGY_WHOLESALE_API_KEY")
 	}
 	if *apiKey == "" {
 		slog.Error("API Key not set!")

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	jsonLogging         = flag.Bool("json", false, "output logs in JSON format")
 	cacheTTLSeconds     = flag.Int64("cache-ttl", 3600, "cache TTL value in seconds for Synergy Wholesale API requests")
 	enableGolangMetrics = flag.Bool("golang-metrics", false, "enable the default golang prometheus collectors")
+	enableDNSSECMetrics = flag.Bool("dnssec-metrics", false, "enable DNSSEC key info metrics")
 )
 
 func main() {
@@ -106,6 +107,7 @@ func main() {
 		"listen_address", *listenAddress,
 		"cache_ttl_seconds", *cacheTTLSeconds,
 		"golang_metrics_enabled", *enableGolangMetrics,
+		"dnssec_metrics_enabled", *enableDNSSECMetrics,
 		"debug_logging", *debugLogging,
 		"json_logging", *jsonLogging,
 	)

--- a/main.go
+++ b/main.go
@@ -81,31 +81,29 @@ func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.domainNameServer
 }
 
-func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
-
+func (collector *Collector) Collect(channel chan<- prometheus.Metric) {
 	listDomainsResp := getDomains()
 	for _, domain := range listDomainsResp.Return.DomainList {
-
 		// skip domains where api status != OK they are usually old/deleted
 		if domain.Status != "OK" {
 			continue
 		}
 
-		ch <- prometheus.MustNewConstMetric(
+		channel <- prometheus.MustNewConstMetric(
 			collector.domainAutoRenew,
 			prometheus.GaugeValue,
 			float64(domain.AutoRenew),
 			domain.DomainName,
 		)
 		for _, dnsSECKey := range domain.DNSSECKeys {
-			ch <- prometheus.MustNewConstMetric(
+			channel <- prometheus.MustNewConstMetric(
 				collector.domainDNSSECKeyInfo,
 				prometheus.GaugeValue,
 				float64(1),
 				domain.DomainName, dnsSECKey.KeyTag, dnsSECKey.Algorithm, dnsSECKey.DigestType, dnsSECKey.Digest,
 			)
 		}
-		ch <- prometheus.MustNewConstMetric(
+		channel <- prometheus.MustNewConstMetric(
 			collector.domainExpiry,
 			prometheus.GaugeValue,
 			float64(domain.GetDomainExpiryTimestamp()),
@@ -113,7 +111,7 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 		)
 
 		for _, server := range domain.NameServers {
-			ch <- prometheus.MustNewConstMetric(
+			channel <- prometheus.MustNewConstMetric(
 				collector.domainNameServer,
 				prometheus.GaugeValue,
 				float64(1),
@@ -131,7 +129,7 @@ func getDomains() api.ListDomainsResponse {
 	slog.Info("Sending listDomains request to Synergy Wholesale API", "reseller_id", *resellerID)
 
 	request := api.ListDomainsRequest{
-		ApiKey:     *apiKey,
+		APIKey:     *apiKey,
 		ResellerID: *resellerID,
 	}
 
@@ -158,7 +156,6 @@ func getDomains() api.ListDomainsResponse {
 }
 
 func main() {
-
 	// parse command-line args
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -7,22 +7,13 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"sync"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	api "github.com/yungwood/synergy-wholesale-exporter/synergywholesaleapi"
 )
 
 var version = "development"
-
-var (
-	listDomainsResponse api.ListDomainsResponse
-	cacheExpires        int64
-	cacheMu             sync.Mutex
-)
 
 var (
 	resellerID           = flag.String("reseller-id", "", "Synergy Wholesale Reseller ID")
@@ -34,133 +25,6 @@ var (
 	cacheTTLSeconds      = flag.Int64("cache-ttl", 3600, "cache TTL value in seconds for Synergy Wholesale API requests")
 	disableGolangMetrics = flag.Bool("no-golang-metrics", false, "disable the default golang prometheus collectors")
 )
-
-var (
-	BuildInfo = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "build_info",
-			Help: "Application build information",
-		},
-		[]string{"version", "goversion"},
-	)
-)
-
-type Collector struct {
-	domainAutoRenew     *prometheus.Desc
-	domainExpiry        *prometheus.Desc
-	domainNameServer    *prometheus.Desc
-	domainDNSSECKeyInfo *prometheus.Desc
-}
-
-func newCollector() *Collector {
-	return &Collector{
-		domainAutoRenew: prometheus.NewDesc("domain_auto_renew_enable",
-			"Domain auto-renewal status",
-			[]string{"domain"},
-			nil,
-		),
-		domainDNSSECKeyInfo: prometheus.NewDesc("domain_dnssec_key_info",
-			"Domain DNSSEC key info",
-			[]string{"domain", "key_tag", "algorithm", "digest_type", "digest"},
-			nil,
-		),
-		domainExpiry: prometheus.NewDesc("domain_expiry_timestamp_seconds",
-			"Domain expiry timestamp in seconds",
-			[]string{"domain", "status"},
-			nil,
-		),
-		domainNameServer: prometheus.NewDesc("domain_name_server_info",
-			"Domain name server info",
-			[]string{"domain", "name_server"},
-			nil,
-		),
-	}
-}
-
-func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- collector.domainAutoRenew
-	ch <- collector.domainExpiry
-	ch <- collector.domainNameServer
-}
-
-func (collector *Collector) Collect(channel chan<- prometheus.Metric) {
-	listDomainsResp := getDomains()
-	for _, domain := range listDomainsResp.Return.DomainList {
-		// skip domains where api status != OK they are usually old/deleted
-		if domain.Status != "OK" {
-			slog.Debug(
-				"Skipping domain with non-OK API status",
-				"domain", domain.DomainName,
-				"status", domain.Status,
-				"error_message", domain.ErrorMessage,
-			)
-			continue
-		}
-
-		channel <- prometheus.MustNewConstMetric(
-			collector.domainAutoRenew,
-			prometheus.GaugeValue,
-			float64(domain.AutoRenew),
-			domain.DomainName,
-		)
-		for _, dnsSECKey := range domain.DNSSECKeys {
-			channel <- prometheus.MustNewConstMetric(
-				collector.domainDNSSECKeyInfo,
-				prometheus.GaugeValue,
-				float64(1),
-				domain.DomainName, dnsSECKey.KeyTag, dnsSECKey.Algorithm, dnsSECKey.DigestType, dnsSECKey.Digest,
-			)
-		}
-		channel <- prometheus.MustNewConstMetric(
-			collector.domainExpiry,
-			prometheus.GaugeValue,
-			float64(domain.GetDomainExpiryTimestamp()),
-			domain.DomainName, domain.DomainStatus,
-		)
-
-		for _, server := range domain.NameServers {
-			channel <- prometheus.MustNewConstMetric(
-				collector.domainNameServer,
-				prometheus.GaugeValue,
-				float64(1),
-				domain.DomainName, server,
-			)
-		}
-	}
-}
-
-func getDomains() api.ListDomainsResponse {
-	cacheMu.Lock()
-	defer cacheMu.Unlock()
-
-	if cacheExpires > time.Now().Unix() {
-		slog.Debug("Using cached Synergy Wholesale domain response", "cache_expires", cacheExpires)
-		return listDomainsResponse
-	}
-
-	slog.Info("Sending listDomains request to Synergy Wholesale API", "reseller_id", *resellerID)
-
-	request := api.ListDomainsRequest{
-		APIKey:     *apiKey,
-		ResellerID: *resellerID,
-	}
-
-	response, err := api.Send(request)
-	if err != nil {
-		slog.Error("Error sending SOAP request", "error", err)
-		return api.ListDomainsResponse{}
-	}
-
-	listDomainsResponse = response
-	cacheExpires = time.Now().Unix() + *cacheTTLSeconds
-	slog.Info(
-		"Updated Synergy Wholesale domain cache",
-		"domain_count", len(response.Return.DomainList),
-		"cache_expires", cacheExpires,
-	)
-
-	return response
-}
 
 func main() {
 	// parse command-line args

--- a/main.go
+++ b/main.go
@@ -16,14 +16,14 @@ import (
 var version = "development"
 
 var (
-	resellerID           = flag.String("reseller-id", "", "Synergy Wholesale Reseller ID")
-	apiKey               = flag.String("apikey", "", "Synergy Wholesale API Key")
-	listenAddress        = flag.String("address", ":8080", "listening port for exporter")
-	printVersion         = flag.Bool("version", false, "print version and exit")
-	debugLogging         = flag.Bool("debug", false, "enable debug logging")
-	jsonLogging          = flag.Bool("json", false, "output logs in JSON format")
-	cacheTTLSeconds      = flag.Int64("cache-ttl", 3600, "cache TTL value in seconds for Synergy Wholesale API requests")
-	disableGolangMetrics = flag.Bool("no-golang-metrics", false, "disable the default golang prometheus collectors")
+	resellerID          = flag.String("reseller-id", "", "Synergy Wholesale Reseller ID")
+	apiKey              = flag.String("apikey", "", "Synergy Wholesale API Key")
+	listenAddress       = flag.String("address", ":8080", "listening port for exporter")
+	printVersion        = flag.Bool("version", false, "print version and exit")
+	debugLogging        = flag.Bool("debug", false, "enable debug logging")
+	jsonLogging         = flag.Bool("json", false, "output logs in JSON format")
+	cacheTTLSeconds     = flag.Int64("cache-ttl", 3600, "cache TTL value in seconds for Synergy Wholesale API requests")
+	enableGolangMetrics = flag.Bool("golang-metrics", false, "enable the default golang prometheus collectors")
 )
 
 func main() {
@@ -73,7 +73,7 @@ func main() {
 	// setup exporter
 	prometheusRegistry := prometheus.NewRegistry()
 	// enable default collectors
-	if !*disableGolangMetrics {
+	if *enableGolangMetrics {
 		prometheusRegistry.MustRegister(
 			collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 			collectors.NewGoCollector(),
@@ -94,7 +94,7 @@ func main() {
 		"Starting web server",
 		"listen_address", *listenAddress,
 		"cache_ttl_seconds", *cacheTTLSeconds,
-		"golang_metrics_enabled", !*disableGolangMetrics,
+		"golang_metrics_enabled", *enableGolangMetrics,
 		"debug_logging", *debugLogging,
 		"json_logging", *jsonLogging,
 	)

--- a/main.go
+++ b/main.go
@@ -88,6 +88,12 @@ func (collector *Collector) Collect(channel chan<- prometheus.Metric) {
 	for _, domain := range listDomainsResp.Return.DomainList {
 		// skip domains where api status != OK they are usually old/deleted
 		if domain.Status != "OK" {
+			slog.Debug(
+				"Skipping domain with non-OK API status",
+				"domain", domain.DomainName,
+				"status", domain.Status,
+				"error_message", domain.ErrorMessage,
+			)
 			continue
 		}
 
@@ -128,6 +134,7 @@ func getDomains() api.ListDomainsResponse {
 	defer cacheMu.Unlock()
 
 	if cacheExpires > time.Now().Unix() {
+		slog.Debug("Using cached Synergy Wholesale domain response", "cache_expires", cacheExpires)
 		return listDomainsResponse
 	}
 
@@ -140,12 +147,17 @@ func getDomains() api.ListDomainsResponse {
 
 	response, err := api.Send(request)
 	if err != nil {
-		fmt.Printf("Error sending SOAP request: %v\n", err)
+		slog.Error("Error sending SOAP request", "error", err)
 		return api.ListDomainsResponse{}
 	}
 
 	listDomainsResponse = response
 	cacheExpires = time.Now().Unix() + *cacheTTLSeconds
+	slog.Info(
+		"Updated Synergy Wholesale domain cache",
+		"domain_count", len(response.Return.DomainList),
+		"cache_expires", cacheExpires,
+	)
 
 	return response
 }
@@ -214,7 +226,14 @@ func main() {
 	http.HandleFunc("/readiness", func(w http.ResponseWriter, r *http.Request) {})
 
 	// start webserver
-	slog.Info("Starting web server", "listen_address", *listenAddress)
+	slog.Info(
+		"Starting web server",
+		"listen_address", *listenAddress,
+		"cache_ttl_seconds", *cacheTTLSeconds,
+		"golang_metrics_enabled", !*disableGolangMetrics,
+		"debug_logging", *debugLogging,
+		"json_logging", *jsonLogging,
+	)
 	if err := http.ListenAndServe(*listenAddress, nil); err != nil {
 		slog.Error("Error starting web server", "error", err)
 	}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	api "github.com/yungwood/synergy-wholesale-exporter/synergywholesaleapi"
 )
 
 var (
@@ -80,10 +81,10 @@ func main() {
 			collectors.NewGoCollector(),
 		)
 	}
-	// add build_info metric
+	// add build information metric
 	BuildInfo.WithLabelValues(version, revision, runtime.Version()).Set(1)
 	collector := newCollector()
-	prometheusRegistry.MustRegister(BuildInfo, HTTPRequestsTotal, collector)
+	prometheusRegistry.MustRegister(BuildInfo, HTTPRequestsTotal, api.SynergyWholesaleAPIRequestsTotal, collector)
 	http.Handle("/metrics", instrumentHTTPHandler(
 		"metrics",
 		promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{}),

--- a/main.go
+++ b/main.go
@@ -83,12 +83,21 @@ func main() {
 	// add build_info metric
 	BuildInfo.WithLabelValues(version, revision, runtime.Version()).Set(1)
 	collector := newCollector()
-	prometheusRegistry.MustRegister(BuildInfo, collector)
-	http.Handle("/metrics", promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{}))
+	prometheusRegistry.MustRegister(BuildInfo, HTTPRequestsTotal, collector)
+	http.Handle("/metrics", instrumentHTTPHandler(
+		"metrics",
+		promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{}),
+	))
 
 	// add a readiness and liveness check endpoint (return blank 200 OK response)
-	http.HandleFunc("/liveness", func(w http.ResponseWriter, r *http.Request) {})
-	http.HandleFunc("/readiness", func(w http.ResponseWriter, r *http.Request) {})
+	http.Handle("/liveness", instrumentHTTPHandler(
+		"liveness",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+	))
+	http.Handle("/readiness", instrumentHTTPHandler(
+		"readiness",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+	))
 
 	// start webserver
 	slog.Info(
@@ -102,4 +111,11 @@ func main() {
 	if err := http.ListenAndServe(*listenAddress, nil); err != nil {
 		slog.Error("Error starting web server", "error", err)
 	}
+}
+
+func instrumentHTTPHandler(handlerName string, handler http.Handler) http.Handler {
+	return promhttp.InstrumentHandlerCounter(
+		HTTPRequestsTotal.MustCurryWith(prometheus.Labels{"handler": handlerName}),
+		handler,
+	)
 }

--- a/main.go
+++ b/main.go
@@ -13,7 +13,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var version = "development"
+var (
+	version  = "development"
+	revision = "unknown"
+)
 
 var (
 	resellerID          = flag.String("reseller-id", "", "Synergy Wholesale Reseller ID")
@@ -78,7 +81,7 @@ func main() {
 		)
 	}
 	// add build_info metric
-	BuildInfo.WithLabelValues(version, runtime.Version()).Set(1)
+	BuildInfo.WithLabelValues(version, revision, runtime.Version()).Set(1)
 	collector := newCollector()
 	prometheusRegistry.MustRegister(BuildInfo, collector)
 	http.Handle("/metrics", promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{}))

--- a/main.go
+++ b/main.go
@@ -133,19 +133,9 @@ func getDomains() api.ListDomainsResponse {
 		ResellerID: *resellerID,
 	}
 
-	data, err := api.SendSOAPRequest(request)
+	response, err := api.Send(request)
 	if err != nil {
 		fmt.Printf("Error sending SOAP request: %v\n", err)
-		return api.ListDomainsResponse{}
-	}
-
-	// Prepare the response struct
-	var response api.ListDomainsResponse
-
-	// Unmarshal the response
-	err2 := api.UnmarshalSOAPResponse(data, &response)
-	if err2 != nil {
-		fmt.Printf("Error: %v\n", err2)
 		return api.ListDomainsResponse{}
 	}
 

--- a/synergywholesaleapi/main.go
+++ b/synergywholesaleapi/main.go
@@ -14,6 +14,8 @@ import (
 // so I opted to write an implementation using core go libraries instead. I have only included
 // the minimum required detail to work with the API
 
+var apiEndpoint = "https://api.synergywholesale.com"
+
 // Define structs for creating requests
 type apiSOAPEnvelope struct {
 	XMLName  xml.Name    `xml:"Envelope"`
@@ -217,7 +219,7 @@ func sendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, "https://api.synergywholesale.com", bytes.NewBuffer(soapRequest))
+	req, err := http.NewRequest(http.MethodPost, apiEndpoint, bytes.NewBuffer(soapRequest))
 	if err != nil {
 		return nil, err
 	}

--- a/synergywholesaleapi/main.go
+++ b/synergywholesaleapi/main.go
@@ -192,21 +192,21 @@ func createSOAPRequest(request interface{}) ([]byte, error) {
 }
 
 func Send(request ListDomainsRequest) (ListDomainsResponse, error) {
-	response, err := SendSOAPRequest(request)
+	response, err := sendSOAPRequest(request)
 	if err != nil {
 		return ListDomainsResponse{}, err
 	}
 
 	// Unmarshal the response
 	var responseObject ListDomainsResponse
-	err2 := UnmarshalSOAPResponse(response, &responseObject)
+	err2 := unmarshalSOAPResponse(response, &responseObject)
 	if err2 != nil {
 		return ListDomainsResponse{}, err2
 	}
 	return responseObject, nil
 }
 
-func SendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
+func sendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 	}
@@ -243,7 +243,7 @@ func SendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
 	return body, nil
 }
 
-func UnmarshalSOAPResponse(data []byte, response interface{}) error {
+func unmarshalSOAPResponse(data []byte, response interface{}) error {
 	var faultEnvelope soapFaultEnvelope
 	if err := xml.NewDecoder(bytes.NewReader(data)).Decode(&faultEnvelope); err != nil {
 		return fmt.Errorf("failed to unmarshal SOAP response: %w", err)

--- a/synergywholesaleapi/main.go
+++ b/synergywholesaleapi/main.go
@@ -29,14 +29,14 @@ type apiSOAPBody struct {
 
 // ListDomainsRequest defines your simple struct
 type ListDomainsRequest struct {
-	ApiKey     string
+	APIKey     string
 	ResellerID string
 }
 
-func (r ListDomainsRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (r ListDomainsRequest) MarshalXML(encoder *xml.Encoder, start xml.StartElement) error {
 	// Start the parent element (listDomains)
 	start.Name.Local = "ns1:listDomains"
-	if err := e.EncodeToken(start); err != nil {
+	if err := encoder.EncodeToken(start); err != nil {
 		slog.Error("Error creating SOAP request", "error", err)
 		return err
 	}
@@ -48,7 +48,7 @@ func (r ListDomainsRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 			{Name: xml.Name{Local: "xsi:type"}, Value: "ns2:Map"},
 		},
 	}
-	if err := e.EncodeToken(paramStart); err != nil {
+	if err := encoder.EncodeToken(paramStart); err != nil {
 		slog.Error("Error creating SOAP request", "error", err)
 		return err
 	}
@@ -58,24 +58,24 @@ func (r ListDomainsRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 		Key   string `xml:"key"`
 		Value string `xml:"value"`
 	}{
-		{Key: "apiKey", Value: r.ApiKey},
+		{Key: "apiKey", Value: r.APIKey},
 		{Key: "resellerID", Value: r.ResellerID},
 	}
 
 	for _, item := range items {
-		if err := e.EncodeElement(item, xml.StartElement{Name: xml.Name{Local: "item"}}); err != nil {
+		if err := encoder.EncodeElement(item, xml.StartElement{Name: xml.Name{Local: "item"}}); err != nil {
 			return err
 		}
 	}
 
 	// End the param element
-	if err := e.EncodeToken(paramStart.End()); err != nil {
+	if err := encoder.EncodeToken(paramStart.End()); err != nil {
 		slog.Error("Error creating SOAP request", "error", err)
 		return err
 	}
 
 	// End the listDomains element
-	if err := e.EncodeToken(start.End()); err != nil {
+	if err := encoder.EncodeToken(start.End()); err != nil {
 		slog.Error("Error creating SOAP request", "error", err)
 		return err
 	}
@@ -182,7 +182,6 @@ func createSOAPRequest(request interface{}) ([]byte, error) {
 }
 
 func Send(request ListDomainsRequest) (interface{}, error) {
-
 	response, err := SendSOAPRequest(request)
 	if err != nil {
 		return nil, err
@@ -198,14 +197,16 @@ func Send(request ListDomainsRequest) (interface{}, error) {
 }
 
 func SendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
 
 	soapRequest, err := createSOAPRequest(param)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", "https://api.synergywholesale.com", bytes.NewBuffer(soapRequest))
+	req, err := http.NewRequest(http.MethodPost, "https://api.synergywholesale.com", bytes.NewBuffer(soapRequest))
 	if err != nil {
 		return nil, err
 	}

--- a/synergywholesaleapi/main.go
+++ b/synergywholesaleapi/main.go
@@ -16,11 +16,12 @@ import (
 
 // Define structs for creating requests
 type apiSOAPEnvelope struct {
-	XMLName xml.Name    `xml:"Envelope"`
-	Xmlns   string      `xml:"xmlns:SOAP-ENV,attr"`
-	Xmlns1  string      `xml:"xmlns:ns1,attr"`
-	Xmlns2  string      `xml:"xmlns:ns2,attr"`
-	Body    apiSOAPBody `xml:"Body"`
+	XMLName  xml.Name    `xml:"Envelope"`
+	Xmlns    string      `xml:"xmlns:SOAP-ENV,attr"`
+	Xmlns1   string      `xml:"xmlns:ns1,attr"`
+	Xmlns2   string      `xml:"xmlns:ns2,attr"`
+	XmlnsXSI string      `xml:"xmlns:xsi,attr"`
+	Body     apiSOAPBody `xml:"Body"`
 }
 
 type apiSOAPBody struct {
@@ -159,11 +160,31 @@ type SOAPResponse struct {
 	}
 }
 
+type soapFault struct {
+	FaultCode   string `xml:"faultcode"`
+	FaultString string `xml:"faultstring"`
+}
+
+func (fault soapFault) Error() string {
+	if fault.FaultCode == "" {
+		return fmt.Sprintf("soap fault: %s", fault.FaultString)
+	}
+	return fmt.Sprintf("soap fault: %s: %s", fault.FaultCode, fault.FaultString)
+}
+
+type soapFaultEnvelope struct {
+	XMLName xml.Name `xml:"Envelope"`
+	Body    struct {
+		Fault *soapFault `xml:"Fault"`
+	} `xml:"Body"`
+}
+
 func createSOAPRequest(request interface{}) ([]byte, error) {
 	envelope := apiSOAPEnvelope{
-		Xmlns:  "http://schemas.xmlsoap.org/soap/envelope/",
-		Xmlns2: "http://xml.apache.org/xml-soap",
-		Xmlns1: "http://api.synergywholesale.com",
+		Xmlns:    "http://schemas.xmlsoap.org/soap/envelope/",
+		Xmlns2:   "http://xml.apache.org/xml-soap",
+		Xmlns1:   "http://api.synergywholesale.com",
+		XmlnsXSI: "http://www.w3.org/2001/XMLSchema-instance",
 		Body: apiSOAPBody{
 			Content: request,
 		},
@@ -226,11 +247,22 @@ func SendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("synergy wholesale api returned status %d: %s", resp.StatusCode, truncateBody(body, 1024))
+	}
 
 	return body, nil
 }
 
 func UnmarshalSOAPResponse(data []byte, response interface{}) error {
+	var faultEnvelope soapFaultEnvelope
+	if err := xml.NewDecoder(bytes.NewReader(data)).Decode(&faultEnvelope); err != nil {
+		return fmt.Errorf("failed to unmarshal SOAP response: %w", err)
+	}
+	if faultEnvelope.Body.Fault != nil {
+		return *faultEnvelope.Body.Fault
+	}
+
 	envelope := apiSOAPEnvelope{
 		Body: apiSOAPBody{
 			Content: response,
@@ -243,4 +275,11 @@ func UnmarshalSOAPResponse(data []byte, response interface{}) error {
 		return fmt.Errorf("failed to unmarshal SOAP response: %w", err)
 	}
 	return nil
+}
+
+func truncateBody(body []byte, limit int) string {
+	if len(body) <= limit {
+		return string(body)
+	}
+	return string(body[:limit]) + "...[truncated]"
 }

--- a/synergywholesaleapi/main.go
+++ b/synergywholesaleapi/main.go
@@ -131,6 +131,7 @@ func dateStringToTimestamp(dateString string) int64 {
 	layout := "2006-01-02 15:04:05"
 	t, err := time.ParseInLocation(layout, dateString, location)
 	if err != nil {
+		slog.Debug("Error parsing date string", "error", err, "date_string", dateString, "layout", layout)
 		return 0
 	}
 	utcTime := t.UTC()
@@ -237,6 +238,7 @@ func sendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		slog.Debug("Synergy Wholesale API returned non-2xx status", "response_code", resp.StatusCode)
 		return nil, fmt.Errorf("synergy wholesale api returned status %d: %s", resp.StatusCode, truncateBody(body, 1024))
 	}
 

--- a/synergywholesaleapi/main.go
+++ b/synergywholesaleapi/main.go
@@ -231,7 +231,11 @@ func sendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
 		SynergyWholesaleAPIRequestsTotal.WithLabelValues("0", "error").Inc()
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Debug("Error closing Synergy Wholesale API response body", "error", err)
+		}
+	}()
 
 	// Log the response status code
 	slog.Debug("Request successful", "response_code", resp.StatusCode)

--- a/synergywholesaleapi/main.go
+++ b/synergywholesaleapi/main.go
@@ -149,17 +149,6 @@ type SOAPResponseCommon struct {
 	ErrorMessage string `xml:"errorMessage,omitempty"`
 }
 
-type SOAPResponse struct {
-	XMLName xml.Name `xml:"Envelope"`
-	Body    struct {
-		XMLName  xml.Name `xml:"Body"`
-		Response struct {
-			XMLName xml.Name `xml:"listDomainsResponse"`
-			ListDomainsResponse
-		}
-	}
-}
-
 type soapFault struct {
 	FaultCode   string `xml:"faultcode"`
 	FaultString string `xml:"faultstring"`
@@ -202,17 +191,17 @@ func createSOAPRequest(request interface{}) ([]byte, error) {
 	return xmlRequest, nil
 }
 
-func Send(request ListDomainsRequest) (interface{}, error) {
+func Send(request ListDomainsRequest) (ListDomainsResponse, error) {
 	response, err := SendSOAPRequest(request)
 	if err != nil {
-		return nil, err
+		return ListDomainsResponse{}, err
 	}
 
 	// Unmarshal the response
 	var responseObject ListDomainsResponse
 	err2 := UnmarshalSOAPResponse(response, &responseObject)
 	if err2 != nil {
-		return nil, err2
+		return ListDomainsResponse{}, err2
 	}
 	return responseObject, nil
 }

--- a/synergywholesaleapi/main.go
+++ b/synergywholesaleapi/main.go
@@ -228,6 +228,7 @@ func sendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
+		SynergyWholesaleAPIRequestsTotal.WithLabelValues("0", "error").Inc()
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -237,13 +238,16 @@ func sendSOAPRequest(param ListDomainsRequest) ([]byte, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		SynergyWholesaleAPIRequestsTotal.WithLabelValues(fmt.Sprintf("%d", resp.StatusCode), "error").Inc()
 		return nil, err
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		SynergyWholesaleAPIRequestsTotal.WithLabelValues(fmt.Sprintf("%d", resp.StatusCode), "error").Inc()
 		slog.Debug("Synergy Wholesale API returned non-2xx status", "response_code", resp.StatusCode)
 		return nil, fmt.Errorf("synergy wholesale api returned status %d: %s", resp.StatusCode, truncateBody(body, 1024))
 	}
 
+	SynergyWholesaleAPIRequestsTotal.WithLabelValues(fmt.Sprintf("%d", resp.StatusCode), "success").Inc()
 	return body, nil
 }
 

--- a/synergywholesaleapi/main_test.go
+++ b/synergywholesaleapi/main_test.go
@@ -156,15 +156,15 @@ func TestDateStringToTimestamp(t *testing.T) {
 }
 
 func TestSendSOAPRequestReturnsErrorForNon2xxStatus(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("request method = %s, want POST", r.Method)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("request method = %s, want POST", request.Method)
 		}
-		if got := r.Header.Get("Content-Type"); got != "text/xml; charset=utf-8" {
+		if got := request.Header.Get("Content-Type"); got != "text/xml; charset=utf-8" {
 			t.Errorf("content type = %q, want text/xml; charset=utf-8", got)
 		}
 
-		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+		http.Error(writer, "upstream unavailable", http.StatusServiceUnavailable)
 	}))
 	defer server.Close()
 

--- a/synergywholesaleapi/main_test.go
+++ b/synergywholesaleapi/main_test.go
@@ -1,0 +1,190 @@
+package synergywholesaleapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUnmarshalSOAPResponseListDomains(t *testing.T) {
+	data, err := os.ReadFile("testdata/list_domains_response.xml")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var response ListDomainsResponse
+	if err := unmarshalSOAPResponse(data, &response); err != nil {
+		t.Fatalf("unmarshal SOAP response: %v", err)
+	}
+
+	if response.Return.Status != "OK" {
+		t.Fatalf("top-level status = %q, want OK", response.Return.Status)
+	}
+
+	domains := response.Return.DomainList
+	if len(domains) != 2 {
+		t.Fatalf("domain count = %d, want 2", len(domains))
+	}
+
+	domain := domains[0]
+	if domain.Status != "OK" {
+		t.Errorf("domain status = %q, want OK", domain.Status)
+	}
+	if domain.DomainName != "example.com" {
+		t.Errorf("domain name = %q, want example.com", domain.DomainName)
+	}
+	if domain.DomainStatus != "ok" {
+		t.Errorf("domain registry status = %q, want ok", domain.DomainStatus)
+	}
+	if domain.AutoRenew != 1 {
+		t.Errorf("auto renew = %d, want 1", domain.AutoRenew)
+	}
+	if domain.DomainExpiry != "2025-01-02 03:04:05" {
+		t.Errorf("domain expiry = %q, want 2025-01-02 03:04:05", domain.DomainExpiry)
+	}
+	if domain.GetDomainExpiryTimestamp() == 0 {
+		t.Error("domain expiry timestamp = 0, want non-zero timestamp")
+	}
+
+	wantNameServers := []string{"ns1.example.net", "ns2.example.net"}
+	if len(domain.NameServers) != len(wantNameServers) {
+		t.Fatalf("nameserver count = %d, want %d", len(domain.NameServers), len(wantNameServers))
+	}
+	for i, want := range wantNameServers {
+		if domain.NameServers[i] != want {
+			t.Errorf("nameserver[%d] = %q, want %q", i, domain.NameServers[i], want)
+		}
+	}
+
+	if len(domain.DNSSECKeys) != 1 {
+		t.Fatalf("DNSSEC key count = %d, want 1", len(domain.DNSSECKeys))
+	}
+	dnsSECKey := domain.DNSSECKeys[0]
+	if dnsSECKey.KeyTag != "12345" {
+		t.Errorf("DNSSEC key tag = %q, want 12345", dnsSECKey.KeyTag)
+	}
+	if dnsSECKey.Algorithm != "13" {
+		t.Errorf("DNSSEC algorithm = %q, want 13", dnsSECKey.Algorithm)
+	}
+	if dnsSECKey.DigestType != "2" {
+		t.Errorf("DNSSEC digest type = %q, want 2", dnsSECKey.DigestType)
+	}
+	if dnsSECKey.Digest != "0000000000000000000000000000000000000000000000000000000000000001" {
+		t.Errorf("DNSSEC digest = %q, want sanitized digest", dnsSECKey.Digest)
+	}
+
+	missingDomain := domains[1]
+	if missingDomain.Status != "ERR_DOMAIN_NOT_FOUND" {
+		t.Errorf("missing domain status = %q, want ERR_DOMAIN_NOT_FOUND", missingDomain.Status)
+	}
+	if missingDomain.ErrorMessage != "Domain name does not exist." {
+		t.Errorf("missing domain error = %q, want Domain name does not exist.", missingDomain.ErrorMessage)
+	}
+	if missingDomain.DomainName != "missing.example" {
+		t.Errorf("missing domain name = %q, want missing.example", missingDomain.DomainName)
+	}
+}
+
+func TestUnmarshalSOAPResponseFault(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <SOAP-ENV:Fault>
+      <faultcode>SOAP-ENV:Client</faultcode>
+      <faultstring>Invalid API key</faultstring>
+    </SOAP-ENV:Fault>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>`)
+
+	var response ListDomainsResponse
+	err := unmarshalSOAPResponse(data, &response)
+	if err == nil {
+		t.Fatal("unmarshal SOAP fault error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "SOAP-ENV:Client") {
+		t.Errorf("fault error = %q, want fault code", err.Error())
+	}
+	if !strings.Contains(err.Error(), "Invalid API key") {
+		t.Errorf("fault error = %q, want fault string", err.Error())
+	}
+}
+
+func TestCreateSOAPRequestListDomains(t *testing.T) {
+	data, err := createSOAPRequest(ListDomainsRequest{
+		APIKey:     "test-api-key",
+		ResellerID: "12345",
+	})
+	if err != nil {
+		t.Fatalf("create SOAP request: %v", err)
+	}
+
+	request := string(data)
+	for _, want := range []string{
+		`<?xml version="1.0" encoding="UTF-8"?>`,
+		`xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"`,
+		`xmlns:ns1="http://api.synergywholesale.com"`,
+		`xmlns:ns2="http://xml.apache.org/xml-soap"`,
+		`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`,
+		`<ns1:listDomains>`,
+		`<param xsi:type="ns2:Map">`,
+		`<key>apiKey</key>`,
+		`<value>test-api-key</value>`,
+		`<key>resellerID</key>`,
+		`<value>12345</value>`,
+	} {
+		if !strings.Contains(request, want) {
+			t.Errorf("SOAP request missing %q:\n%s", want, request)
+		}
+	}
+}
+
+func TestDateStringToTimestamp(t *testing.T) {
+	timestamp := dateStringToTimestamp("2025-01-02 03:04:05")
+	if timestamp != 1735751045 {
+		t.Errorf("timestamp = %d, want 1735751045", timestamp)
+	}
+
+	if timestamp := dateStringToTimestamp(""); timestamp != 0 {
+		t.Errorf("empty timestamp = %d, want 0", timestamp)
+	}
+
+	if timestamp := dateStringToTimestamp("not-a-date"); timestamp != 0 {
+		t.Errorf("invalid timestamp = %d, want 0", timestamp)
+	}
+}
+
+func TestSendSOAPRequestReturnsErrorForNon2xxStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("request method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "text/xml; charset=utf-8" {
+			t.Errorf("content type = %q, want text/xml; charset=utf-8", got)
+		}
+
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	originalAPIEndpoint := apiEndpoint
+	apiEndpoint = server.URL
+	t.Cleanup(func() {
+		apiEndpoint = originalAPIEndpoint
+	})
+
+	_, err := sendSOAPRequest(ListDomainsRequest{
+		APIKey:     "test-api-key",
+		ResellerID: "12345",
+	})
+	if err == nil {
+		t.Fatal("send SOAP request error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "status 503") {
+		t.Errorf("error = %q, want status 503", err.Error())
+	}
+	if !strings.Contains(err.Error(), "upstream unavailable") {
+		t.Errorf("error = %q, want response body snippet", err.Error())
+	}
+}

--- a/synergywholesaleapi/metrics.go
+++ b/synergywholesaleapi/metrics.go
@@ -1,0 +1,14 @@
+package synergywholesaleapi
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const metricNamespace = "synergy_wholesale"
+
+var SynergyWholesaleAPIRequestsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metricNamespace,
+		Name:      "api_requests_total",
+		Help:      "Total number of HTTP requests sent to the Synergy Wholesale API.",
+	},
+	[]string{"code", "result"},
+)

--- a/synergywholesaleapi/testdata/list_domains_response.xml
+++ b/synergywholesaleapi/testdata/list_domains_response.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:WholesaleSystem" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <SOAP-ENV:Body>
+    <ns1:listDomainsResponse xmlns:ns1="http://api.synergywholesale.com">
+      <return xsi:type="tns:bulkDomainInfoResponse">
+        <status xsi:type="xsd:string">OK</status>
+        <domainList xsi:type="SOAP-ENC:Array" SOAP-ENC:arrayType="tns:bulkDomainInfoResponseSingleEntry[2]">
+          <item xsi:type="tns:bulkDomainInfoResponseSingleEntry">
+            <status xsi:type="xsd:string">OK</status>
+            <domainName xsi:type="xsd:string">example.com</domainName>
+            <domain_status xsi:type="xsd:string">ok</domain_status>
+            <domain_expiry xsi:type="xsd:string">2025-01-02 03:04:05</domain_expiry>
+            <nameServers xsi:type="SOAP-ENC:Array" SOAP-ENC:arrayType="xsd:string[2]">
+              <item xsi:type="xsd:string">ns1.example.net</item>
+              <item xsi:type="xsd:string">ns2.example.net</item>
+            </nameServers>
+            <autoRenew xsi:type="xsd:int">1</autoRenew>
+            <DSData xsi:type="SOAP-ENC:Array" SOAP-ENC:arrayType="tns:singleDNSSECDSData[1]">
+              <item xsi:type="tns:singleDNSSECDSData">
+                <keyTag xsi:type="xsd:int">12345</keyTag>
+                <algorithm xsi:type="xsd:int">13</algorithm>
+                <digest xsi:type="xsd:string">0000000000000000000000000000000000000000000000000000000000000001</digest>
+                <digestType xsi:type="xsd:int">2</digestType>
+              </item>
+            </DSData>
+          </item>
+          <item xsi:type="tns:bulkDomainInfoResponseSingleEntry">
+            <status xsi:type="xsd:string">ERR_DOMAIN_NOT_FOUND</status>
+            <errorMessage xsi:type="xsd:string">Domain name does not exist.</errorMessage>
+            <domainName xsi:type="xsd:string">missing.example</domainName>
+          </item>
+        </domainList>
+        <page xsi:type="xsd:int">1</page>
+        <limit xsi:type="xsd:int">500</limit>
+      </return>
+    </ns1:listDomainsResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
- add structured metrics for exporter HTTP requests and upstream Synergy Wholesale API requests.
- breaking: prefix all metrics with the `synergy_wholesale` namespace.
- Add `revision` to `build_info` metric.
- Make Go/process metrics and DNSSEC key metrics opt-in.
- Add env var support for all runtime config flags.
- Improve SOAP request handling.
- Split exporter code into focused files for config, cache, and collectors.
- Improve Dockerfile caching, OCI labels, BuildKit support.
- Add some tests.